### PR TITLE
Record aggregate distortion per attribute/file along the Markov chain

### DIFF
--- a/R/ExchangERFit.R
+++ b/R/ExchangERFit.R
@@ -26,6 +26,9 @@ NULL
 #'   \item{distort_probs}{a [`coda::mcmc`] matrix object recording 
 #'     the distortion probabilities for each attribute/file. Rows index samples 
 #'     along the Markov chain and columns index attributes/files.}
+#'   \item{distort_counts}{a [`coda::mcmc`] matrix object recording 
+#'     the number of distorted values for each attribute/file. Rows index 
+#'     samples along the Markov chain and columns index attributes/files.}
 #'   \item{n_linked_ents}{a [`coda::mcmc`] vector object recording the 
 #'     total number of entities (clusters) that are linked to at least one 
 #'     record.}
@@ -45,7 +48,7 @@ setMethod("show", "ExchangERFit", function(object) {
   n_samples <- end_iter - start_iter + thin
   
   # Compute effective sample size for particular variables, if present
-  valid_ess_varnames <- c("n_linked_ents", "distort_probs", "clust_params")
+  valid_ess_varnames <- c("n_linked_ents", "distort_probs", "distort_counts", "clust_params")
   ess <- list()
   for (varname in intersect(valid_ess_varnames, names(object@history))) {
     var <- object@history[[varname]]

--- a/man/ExchangERFit-class.Rd
+++ b/man/ExchangERFit-class.Rd
@@ -22,6 +22,9 @@ same integer value are assigned to the same entity.}
 \item{distort_probs}{a \code{\link[coda:mcmc]{coda::mcmc}} matrix object recording
 the distortion probabilities for each attribute/file. Rows index samples
 along the Markov chain and columns index attributes/files.}
+\item{distort_counts}{a \code{\link[coda:mcmc]{coda::mcmc}} matrix object recording
+the number of distorted values for each attribute/file. Rows index
+samples along the Markov chain and columns index attributes/files.}
 \item{n_linked_ents}{a \code{\link[coda:mcmc]{coda::mcmc}} vector object recording the
 total number of entities (clusters) that are linked to at least one
 record.}

--- a/src/records.cpp
+++ b/src/records.cpp
@@ -23,14 +23,14 @@ bool Records::get_attribute_distortion(rec_id rid, attr_id aid) const
 
 int Records::n_distorted(file_id fid, attr_id aid) const 
 {
-  return distortion_counts_(fid, aid);
+  return distorted_counts_(fid, aid);
 }
 
 void Records::set_attribute_distortion(rec_id rid, attr_id aid, bool distorted) 
 {
   int &oldDist = attr_distortions_(aid, rid);
   file_id fid = get_file_id(rid);
-  distortion_counts_(fid, aid) += distorted - oldDist;
+  distorted_counts_(fid, aid) += distorted - oldDist;
   oldDist = distorted;
 }
 
@@ -39,11 +39,9 @@ Rcpp::IntegerMatrix Records::R_rec_distortions() const
   return Rcpp::wrap(attr_distortions_);
 }
 
-Rcpp::IntegerVector Records::R_n_distorted_per_attr() const 
+Rcpp::IntegerMatrix Records::R_distorted_counts() const 
 {
-  // Sum over files
-  arma::irowvec n_distorted_per_attr = arma::sum(distortion_counts_, 0);
-  return Rcpp::wrap(n_distorted_per_attr);
+  return Rcpp::wrap(distorted_counts_);
 }
 
 Rcpp::IntegerVector Records::R_n_distorted_per_rec() const 

--- a/src/records.h
+++ b/src/records.h
@@ -21,7 +21,7 @@ private:
   const arma::ivec fids_;
   arma::imat attr_distortions_;
   const arma::ivec fsizes_;
-  arma::imat distortion_counts_;
+  arma::imat distorted_counts_;
 
   /**
    * Setter for the distortion indicator of a record attribute
@@ -106,7 +106,7 @@ public:
    * file/attribute. Rows correspond to files and columns correspond to 
    * attributes.
    */
-  Rcpp::IntegerVector R_n_distorted_per_attr() const;
+  Rcpp::IntegerMatrix R_distorted_counts() const;
 
   /**
    * TODO
@@ -130,11 +130,11 @@ public:
       attr_distortions_(attr_distortions), 
       fsizes_(fsizes)
   {
-    distortion_counts_ = arma::zeros<arma::imat>(n_files(), n_attributes());
+    distorted_counts_ = arma::zeros<arma::imat>(n_files(), n_attributes());
     for (rec_id rid=0; rid < n_records(); rid++) {
       file_id fid = fids_[rid];
       for (attr_id aid=0; aid < n_attributes(); aid++) {
-        if (get_attribute_distortion(rid, aid)) { distortion_counts_(fid, aid) += 1; }
+        if (get_attribute_distortion(rid, aid)) { distorted_counts_(fid, aid) += 1; }
       }
     }
   }

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -147,6 +147,9 @@ int burnin_interval=0)
   Rcpp::IntegerMatrix hist_n_linked_ents(n_samples, 1);
   colnames(hist_n_linked_ents) = Rcpp::CharacterVector::create("n_linked_ents");
   
+  Rcpp::IntegerMatrix hist_distort_counts(n_samples, state.recs_.n_attributes() * state.recs_.n_files());
+  colnames(hist_distort_counts) = hist_distort_probs_nms;
+  
   Rcpp::NumericMatrix hist_clust_params;
   if (clust_params->num_random() > 0) {
     Rcpp::CharacterVector clust_param_names = clust_params->to_R_vec().names();
@@ -171,11 +174,12 @@ int burnin_interval=0)
       {
         // Update history using this sample
         Rcpp::IntegerVector links_R = state.links_.to_R();
-        Rcpp::IntegerVector n_distorted = state.recs_.R_n_distorted_per_attr();
         hist_links.row(sample_ctr) = links_R;
         hist_n_linked_ents(sample_ctr, 0) = state.links_.n_linked_ents();
         Rcpp::NumericVector distort_prob = state.distort_probs_.to_R();
         hist_distort_probs.row(sample_ctr) = distort_prob;
+        Rcpp::IntegerVector distort_counts = state.recs_.R_distorted_counts();
+        hist_distort_counts.row(sample_ctr) = distort_counts;
         if (hist_clust_params.ncol() > 0) {
           hist_clust_params.row(sample_ctr) = clust_params->to_R_vec();
         }
@@ -195,6 +199,7 @@ int burnin_interval=0)
   Rcpp::List history;
   history["links"] = hist_links;
   history["distort_probs"] = hist_distort_probs;
+  history["distort_counts"] = hist_distort_counts;
   history["n_linked_ents"] = hist_n_linked_ents;
   if (hist_clust_params.ncol() > 0) history["clust_params"] = hist_clust_params;
   result.slot("history") = history;

--- a/vignettes/RLdata500.Rmd
+++ b/vignettes/RLdata500.Rmd
@@ -85,8 +85,10 @@ the small number of samples.
 ```{r}
 n_linked_ents <- extract(result, "n_linked_ents")
 distort_probs <- extract(result, "distort_probs")
+distort_counts <- extract(result, "distort_counts")
 plot(n_linked_ents)
 plot(distort_probs)
+plot(distort_counts)
 ```
 
 We can obtain a point estimate of the most likely linkage structure using the 


### PR DESCRIPTION
The number of distorted record values per attribute/file is useful for
assessing the behavior of the distortion model.